### PR TITLE
Enhance book cover image loading with WebP support and improved placeholders

### DIFF
--- a/layouts/books/single.html
+++ b/layouts/books/single.html
@@ -9,9 +9,37 @@
       <div class="flex flex-col md:flex-row gap-8">
         <!-- Book Cover -->
         <figure class="book-cover w-full md:w-1/3 flex-shrink-0">
-          <img class="w-full h-auto object-contain rounded-lg shadow-md"
-               src="{{ if .Params.cover }}{{ .Params.cover }}{{ else }}{{ "images/placeholder.webp" | relURL }}{{ end }}"
-               alt="Cover of {{ .Params.book_title }}" loading="lazy">
+          {{ $imageUrl := "" }}
+          {{ $directUrl := "" }}
+          {{ $placeholderImage := "images/placeholder.webp" | relURL }}
+          {{ if .Params.cover }}
+              {{ $directUrl = .Params.cover }}
+              {{ $imageUrl = printf "https://images.weserv.nl/?url=%s&amp;w=600&amp;h=900&amp;fit=inside&amp;output=webp&amp;q=85" (.Params.cover | urlquery) }}
+          {{ else }}
+              {{ $imageUrl = $placeholderImage }}
+              {{ $directUrl = $placeholderImage }}
+          {{ end }}
+          <a href="{{ .RelPermalink }}" class="block relative w-full">
+              <!-- Placeholder shown while loading -->
+              <img class="w-full h-auto object-contain rounded-lg shadow-md absolute inset-0 transition-opacity duration-300"
+                   src="{{ $placeholderImage }}"
+                   alt="Loading..."
+                   aria-hidden="true"
+                   data-placeholder-for="cover">
+              <!-- Main image loaded on top -->
+              <img class="w-full h-auto object-contain rounded-lg shadow-md absolute inset-0 transition-opacity duration-300 opacity-0"
+                   src="{{ $imageUrl }}"
+                   data-direct-url="{{ $directUrl }}"
+                   data-placeholder="{{ $placeholderImage }}"
+                   alt="Cover of {{ .Params.book_title }}"
+                   loading="lazy"
+                   onload="this.classList.remove('opacity-0'); this.previousElementSibling.classList.add('opacity-0'); this.parentElement.style.paddingBottom = (this.height / this.width * 100) + '%';"
+                   onerror="if(this.src !== this.dataset.directUrl) {
+                             this.src = this.dataset.directUrl;
+                           } else if(this.src !== this.dataset.placeholder) {
+                             this.src = this.dataset.placeholder;
+                           }">
+          </a>
         </figure>
 
         <div class="w-full md:w-2/3">

--- a/layouts/partials/book/card.html
+++ b/layouts/partials/book/card.html
@@ -9,7 +9,10 @@
 <article class="book-card bg-secondary dark:bg-secondary-dark shadow-lg rounded-lg overflow-hidden transition duration-300 ease-in-out transform hover:shadow-xl flex flex-col"
          {{ with .File }}data-slug="{{ .ContentBaseName }}"{{ end }}>
 
-    {{ partial "book/components/cover-image.html" .Params }}
+    {{ partial "book/components/cover-image.html" (dict
+        "cover" .Params.cover
+        "book_title" .Params.book_title
+        "permalink" .RelPermalink) }}
 
     <div class="p-4 flex flex-col flex-grow">
         {{ partial "book/components/title-section.html" . }}

--- a/layouts/partials/book/components/cover-image.html
+++ b/layouts/partials/book/components/cover-image.html
@@ -1,10 +1,35 @@
 {{ $placeholderImage := "images/placeholder.webp" | relURL }}
 <div class="h-64 overflow-hidden relative">
-    <a href="{{ .RelPermalink }}" class="block w-full h-full">
-        <img class="w-full h-full object-contain transition-opacity duration-300"
-             src="{{ if .cover }}{{ .cover }}{{ else }}{{ $placeholderImage }}{{ end }}"
-             onerror="this.onerror=null; this.src='{{ $placeholderImage }}'"
-             alt="{{ .book_title }}"
-             loading="lazy">
+    <a href="{{ .permalink }}" class="block w-full h-full">
+        {{ $imageUrl := "" }}
+        {{ $directUrl := "" }}
+        {{ if .cover }}
+            {{ $directUrl = .cover }}
+            {{ $imageUrl = printf "https://images.weserv.nl/?url=%s&amp;w=400&amp;h=600&amp;fit=inside&amp;output=webp&amp;q=85" (.cover | urlquery) }}
+        {{ else }}
+            {{ $imageUrl = $placeholderImage }}
+            {{ $directUrl = $placeholderImage }}
+        {{ end }}
+        <div class="relative w-full h-full">
+            <!-- Placeholder shown while loading -->
+            <img class="w-full h-full object-contain absolute inset-0 transition-opacity duration-300"
+                 src="{{ $placeholderImage }}"
+                 alt="Loading..."
+                 aria-hidden="true"
+                 data-placeholder-for="cover">
+            <!-- Main image loaded on top -->
+            <img class="w-full h-full object-contain absolute inset-0 transition-opacity duration-300 opacity-0"
+                 src="{{ $imageUrl }}"
+                 data-direct-url="{{ $directUrl }}"
+                 data-placeholder="{{ $placeholderImage }}"
+                 alt="{{ .book_title }}"
+                 loading="lazy"
+                 onload="this.classList.remove('opacity-0'); this.previousElementSibling.classList.add('opacity-0');"
+                 onerror="if(this.src !== this.dataset.directUrl) {
+                           this.src = this.dataset.directUrl;
+                         } else if(this.src !== this.dataset.placeholder) {
+                           this.src = this.dataset.placeholder;
+                         }">
+        </div>
     </a>
 </div>


### PR DESCRIPTION
- Updated the book cover image implementation in `single.html`, `card.html`, and `cover-image.html` to utilize WebP format for better performance.
- Introduced a loading placeholder that transitions to the main image once loaded, enhancing user experience.
- Refactored image handling to include direct URLs and fallback mechanisms for improved reliability and accessibility.