### PR TITLE
Add Netlify badge to site footer

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Code of Conduct
+
+## Our Commitment
+
+The LGBTQIA+ Literature Catalog is committed to providing a privacy-focused, accessible resource for discovering queer literature across different languages. We maintain this catalog as a static website to ensure fast access, offline capabilities, and resistance to censorship.
+
+## Project Scope
+
+This project:
+
+- Maintains a curated catalog of LGBTQIA+ literature with their translations
+- Operates without user accounts or user-generated content
+- Prioritizes visitor privacy by minimizing tracking capabilities
+- Provides offline access through downloadable archives
+- Accepts content contributions only through:
+  1. Direct pull requests to the GitHub repository
+  2. Authorized editors via the content management system
+
+## Contribution Standards
+
+For those contributing through pull requests or the CMS, we expect:
+
+- Accurate and verifiable book information
+- Respect for copyright and fair use
+- Clear, factual descriptions without bias
+- Proper attribution of sources
+- Adherence to the project's content format and structure
+
+## Privacy Commitment
+
+We are committed to:
+
+- Minimizing data collection
+- Avoiding third-party tracking scripts
+- Not implementing social media integration
+- Providing downloadable archives for offline use
+- Being transparent about any data collected by our hosting provider (Netlify)
+
+## Enforcement
+
+Project maintainers will review all pull requests and CMS contributions to ensure they align with these standards. We reserve the right to:
+
+- Reject contributions that don't meet our quality or format requirements
+- Remove inaccurate or inappropriate content
+- Revoke CMS access for those who repeatedly violate these standards
+
+## Contact
+
+For questions, corrections, or to report technical issues:
+
+1. Open an issue in [our GitHub repository](https://github.com/Dimm-ddr/loudlyproud)
+2. Contact the project maintainer through the contact information provided in the repository
+
+## Attribution
+
+This is an independent project focused on making LGBTQIA+ literature more discoverable while respecting user privacy and fighting censorship.

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -122,19 +122,24 @@
 
 /* Typography utility classes */
 .text-heading {
-  @apply font-black text-gray-900;
+  @apply font-black text-gray-900 dark:text-gray-50;
 }
 
 .text-subheading {
-  @apply font-bold text-gray-700;
+  @apply font-bold text-gray-800 dark:text-gray-100;
 }
 
 .text-body {
-  @apply font-normal text-gray-600;
+  @apply font-normal text-gray-700 dark:text-gray-200;
 }
 
 .text-caption {
-  @apply font-light text-gray-500;
+  @apply font-normal text-gray-600 dark:text-gray-300;
+}
+
+/* Special case for italic captions to compensate for thinner appearance */
+.text-caption.italic {
+  @apply font-medium;
 }
 
 /* Scrollbar Styles */

--- a/layouts/partials/book/components/title-section.html
+++ b/layouts/partials/book/components/title-section.html
@@ -6,7 +6,7 @@
         </a>
     </h2>
     {{ with .Params.series }}
-    <p class="text-base font-light italic text-gray-500">
+    <p class="text-base text-caption italic">
         {{ . }}
     </p>
     {{ end }}

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -8,11 +8,15 @@
       </div>
       {{ end }}
 
-      <!-- Telegram Link -->
-      <div>
+      <!-- Telegram Link and Netlify Badge -->
+      <div class="flex items-center space-x-4">
         <a href="https://t.me/loudlyProud"
            class="styled-link hover:text-gray-900{{ if .Site.Params.darkMode }} dark:hover:text-gray-100{{ end }}">
           {{ i18n "telegram_updates" }}
+        </a>
+        <span class="text-gray-400">•</span>
+        <a href="https://www.netlify.com" class="opacity-70 hover:opacity-100 transition-opacity">
+          <img src="https://www.netlify.com/v3/img/components/netlify-light.svg" alt="Deploys by Netlify" class="h-5">
         </a>
       </div>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,12 +72,12 @@ module.exports = {
           },
           burgundy: {
             light: {
-              DEFAULT: "#991b1b", // red-800
-              hover: "#b91c1c", // red-700
+              DEFAULT: "#7e1d5f", // custom purple-red
+              hover: "#9d2975", // lighter purple-red
             },
             dark: {
-              DEFAULT: "#f87171", // red-400
-              hover: "#fca5a5", // red-300
+              DEFAULT: "#e391c3", // light purple-pink
+              hover: "#edb3d5", // lighter purple-pink
             },
           },
           "deep-blue": {


### PR DESCRIPTION
- Integrated Netlify deployment badge next to Telegram link
- Used Tailwind CSS for responsive and styled placement
- Maintained existing footer layout and dark mode compatibility