### PR TITLE
feat: add testing configuration files

### DIFF
--- a/.linkinator.config.json
+++ b/.linkinator.config.json
@@ -1,0 +1,13 @@
+{
+  "path": "public",
+  "recurse": true,
+  "skip": [
+    "fonts",
+    ".css$",
+    ".js$",
+    ".woff2$",
+    "admin/*"
+  ],
+  "silent": false,
+  "verbosity": "error"
+}

--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -1,0 +1,17 @@
+{
+  "defaults": {
+    "standard": "WCAG2AA",
+    "timeout": 10000,
+    "wait": 1000,
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+    }
+  },
+  "urls": [
+    "public/index.html",
+    "public/en/index.html",
+    "public/ru/index.html",
+    "public/fa/index.html",
+    "public/en/main/index.html"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "linkinator": "^6.0.0",
     "pa11y-ci": "^3.0.0",
     "glob": "^10.3.0",
-    "@types/glob": "^8.1.0",
-    "http-server": "^14.1.1"
+    "@types/glob": "^8.1.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "linkinator": "^6.0.0",
     "pa11y-ci": "^3.0.0",
     "glob": "^10.3.0",
-    "@types/glob": "^8.1.0"
+    "@types/glob": "^8.1.0",
+    "http-server": "^14.1.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,20 @@
     "build:config": "node scripts/build-config.js",
     "clean": "rimraf public && rimraf \"static/js\"",
     "cms": "decap-server",
-    "tools": "poetry --directory .tools"
+    "tools": "poetry --directory .tools",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui",
+    "test:unit": "vitest run --config vitest.config.unit.ts",
+    "test:integration": "vitest run --config vitest.config.integration.ts",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug",
+    "test:a11y": "pa11y-ci",
+    "test:links": "linkinator public --recurse --skip 'fonts|.css|.js' --verbosity error",
+    "test:all": "pnpm run test:unit && pnpm run build && pnpm run test:integration && pnpm run test:e2e && pnpm run test:links",
+    "playwright:install": "playwright install --with-deps chromium",
+    "validate:tests": "node scripts/validate-tests.js"
   },
   "dependencies": {
     "alpinejs": "^3.15.0",
@@ -39,7 +52,19 @@
     "pretty-error": "^4.0.0",
     "rimraf": "^5.0.10",
     "typescript": "^5.9.2",
-    "wait-on": "^8.0.5"
+    "wait-on": "^8.0.5",
+    "vitest": "^1.0.0",
+    "@vitest/ui": "^1.0.0",
+    "jsdom": "^23.0.0",
+    "cheerio": "^1.0.0-rc.12",
+    "@playwright/test": "^1.40.0",
+    "@axe-core/playwright": "^4.8.0",
+    "happy-dom": "^12.10.0",
+    "@testing-library/dom": "^9.3.3",
+    "linkinator": "^6.0.0",
+    "pa11y-ci": "^3.0.0",
+    "glob": "^10.3.0",
+    "@types/glob": "^8.1.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PORT || 4173;
+const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npx http-server public -p 4173 --silent',
+    port: 4173,
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npx http-server public -p 4173 --silent',
+    command:
+      'hugo server --port 4173 --baseURL http://localhost:4173 --environment production --disableLiveReload --disableFastRender --bind 127.0.0.1',
     port: 4173,
     timeout: 120000,
     reuseExistingServer: !process.env.CI,

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    name: 'integration',
+    environment: 'jsdom',
+    include: ['tests/integration/**/*.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    globals: true,
+    testTimeout: 10000,
+    setupFiles: ['./tests/setup/integration.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './assets'),
+      '@src': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    name: 'unit',
+    environment: 'jsdom',
+    include: ['tests/unit/**/*.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/public/**'],
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['assets/js/**/*.ts', 'src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/vendor/**', '**/*.d.ts'],
+    },
+    setupFiles: ['./tests/setup/unit.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './assets'),
+      '@src': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add comprehensive testing scripts for unit, integration, e2e, accessibility, and link checks
- add necessary testing devDependencies including Vitest, Playwright, and accessibility tooling
- create configuration files for Vitest, Playwright, Pa11y, and Linkinator to support the new testing workflows

## Testing
- not run (not required for configuration task)

------
https://chatgpt.com/codex/tasks/task_e_68f780bb83d8832aaa2653f9ceb21e4c